### PR TITLE
fixed duplicated items in history

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -40,8 +40,10 @@ $("#searchBtn").on("click", async function(e) {
 
 
 function storeMovie (movie) {
-    movieArray.push(movie);
-    localStorage.setItem("search-history", JSON.stringify(movieArray));
+    if (!movieArray.includes(movie)) {
+        movieArray.push(movie);
+        localStorage.setItem("search-history", JSON.stringify(movieArray));
+    }
     checkArray();
 }
 


### PR DESCRIPTION
The dropdown menu for search history was showing duplicated searches. I added an if statement to the function storeMovie to check if the item is already there before storing. 